### PR TITLE
Added missing modules to vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,5 @@ data/**
 webpack.config.json
 node_modules
 !node_modules/copy-paste
+!node_modules/iconv-lite
+!node_modules/sync-exec


### PR DESCRIPTION
Added two lines to .vscodeignore that will force VS Code to not ignore the dependencies of iconv-lite.

It fixes #103 and fixes #104.