### PR TITLE
Add link to .Net formatting to the settings description

### DIFF
--- a/package.json
+++ b/package.json
@@ -351,7 +351,7 @@
                 "csv-preview.numberFormat": {
                     "type": "string",
                     "default": "g2",
-                    "description": "Specifies a .NET-style format string used to format numeric columns in CSV files."
+                    "markdownDescription": "Specifies a [.NET-style format string](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings) used to format numeric columns in CSV files."
                 },
                 "csv-preview.openStdin": {
                     "type": "boolean",


### PR DESCRIPTION
This makes it easier to find the formatting options.

I could also add the following, which would probably prevent #172:
> You may need to run the `CSV: Clear Preview State` command to see the effects of changing this setting.

